### PR TITLE
Add README cross links without removing content

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 本项目是一个基于微信小程序的面向程序员的书城，简称微书，前端使用Uniapp框架，后端使用SpringBoot
+[English README](README_en.md)
 
 后端去把application.yml中的端口，redis，mongo和MySQL的地址修改一下，然后到com.book.controller.user.UserController里面把阿里云OSS的配置修改一下：
 

--- a/README_en.md
+++ b/README_en.md
@@ -1,0 +1,35 @@
+# ProgramBook
+
+[中文 README](README.md)
+
+This project is a WeChat mini program bookstore for programmers (ProgramBook). The frontend uses the Uniapp framework and the backend uses SpringBoot.
+
+Modify the port, Redis, MongoDB and MySQL addresses in `application.yml`, and update the Alibaba Cloud OSS settings in `com.book.controller.user.UserController`:
+
+![Snipaste_2023-06-04_10-57-07](/images/Snipaste_2023-06-04_10-57-07.png)
+
+Import the MongoDB and MySQL data, then start the service.
+
+For the frontend, open the project in HBuilderX and change the `HOST_URL` IP in `/utils/api/api.js` to your own before running it in the mini program simulator.
+
+![image-20230404181954029](/images/image-20230404181954029.png)
+
+## Screenshots
+
+![image-20230404182232643](/images/image-20230404182232643.png)
+
+![image-20230404182401471](/images/image-20230404182401471.png)
+
+![image-20230404182610721](/images/image-20230404182610721.png)
+
+![image-20230404182651488](/images/image-20230404182651488.png)
+
+![image-20230404182802737](/images/image-20230404182802737.png)
+
+## Contributing
+
+Maintained by the author.
+
+## License
+
+GPL


### PR DESCRIPTION
## Summary
- revert `README.md` to original text and insert a link to `README_en.md`
- rewrite `README_en.md` as an English translation and link back to Chinese README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685915e5e6ec8322a8d5b6b47526d90c